### PR TITLE
Change PCRE download URL to https://ftp.pcre.org/pub/pcre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN \
     && cd /tmp \
     && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-    && curl -fSL https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && curl -fSL https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
     && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \


### PR DESCRIPTION
This is a reflection of an
[upstream change in docker-openresty](https://github.com/openresty/docker-openresty/commit/13607d7229e8f72b4b8f4bcb816018b153043221) as
ftp.csx.cam.ac.uk appears to have let their SSL certificate expire.

It's a shame to have to reflect these changes like this, perhaps we
can push up our own OpenResty image with `--without-luajit-lua52`
set in `RESTY_CONFIG_OPTIONS`, or perhaps there is a pre-built
package with the desired options set somewhere we can use?