### PR TITLE
Make kong wait for postgres before attempting to start

### DIFF
--- a/conf/kong-entrypoint.sh
+++ b/conf/kong-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [[ "$1" = '--nowait' || "$1" = '-W' ]]; then
+    echo "Skip waiting for DB..."
+else
+    while ! (echo > /dev/tcp/postgres/5432) >/dev/null 2>&1
+    do
+        echo "Waiting for DB..."
+        sleep 1
+    done
+fi
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,14 @@ services:
       dockerfile: "Dockerfile"
     image: "mrsaints/kong-dev"
     command: ["kong", "start", "-v"]
+    entrypoint: /kong-entrypoint.sh
     environment:
       - KONG_DATABASE=postgres
       - KONG_PG_HOST=postgres
       # Disable daemon mode so the container won't exit immediately
       # - KONG_NGINX_DAEMON=off
-    # volumes:
+    volumes:
+      - ./conf/kong-entrypoint.sh:/kong-entrypoint.sh
       # Mount local Kong repository
       # - ./kong/:/kong/
       # Mount custom plugin


### PR DESCRIPTION
If kong tries to start prematurely, before postgres is ready it will simply exit. To prevent this we add an entry point which will periodically poll the postgres 5432 port to check availability and if it is, start Kong.