### PR TITLE
Software upgrade 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ ENV KONG_LUA_CODE_CACHE=false
 ENV KONG_LOG_LEVEL=debug
 
 # Set kong version
-ENV KONG_VERSION=0.11.0
+ENV KONG_VERSION=c7b4b48e6fd26c2789e38458d0a099ef08e631bb
 
 # Install Kong from source
 RUN mkdir /kong/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ ENV KONG_LUA_CODE_CACHE=false
 # Enable detailed logging
 ENV KONG_LOG_LEVEL=debug
 
-# Set kong version
+# Set Kong version
 ENV KONG_VERSION=c7b4b48e6fd26c2789e38458d0a099ef08e631bb
 
 # Install Kong from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ LABEL maintainer "Evan Wies <evan@neomantra.net>, Ian L. <os@fyianlai.com>"
 ARG SERF_VERSION="0.7.0"
 
 # `--without-luajit-lua52` compilation flag is required
-# for Kong to work with OpenResty 1.11.2.2
-ARG RESTY_VERSION="1.11.2.2"
+# for Kong to work with OpenResty 1.11.2.4
+ARG RESTY_VERSION="1.11.2.4"
 
 ARG RESTY_LUAROCKS_VERSION="2.4.2"
 ARG RESTY_OPENSSL_VERSION="1.0.2j"
@@ -145,10 +145,14 @@ ENV KONG_LUA_CODE_CACHE=false
 # Enable detailed logging
 ENV KONG_LOG_LEVEL=debug
 
+# Set kong version
+ENV KONG_VERSION=0.11.0
+
 # Install Kong from source
 RUN mkdir /kong/ \
     && cd /kong/ \
     && git clone https://github.com/Mashape/kong.git . \
+    && git checkout $KONG_VERSION \
     && make install \
     && make dev \
     && apk del .build-deps

--- a/conf/kong-entrypoint.sh
+++ b/conf/kong-entrypoint.sh
@@ -11,10 +11,13 @@ else
     done
 fi
 
-# remove hosts configs for busted tests
+# Remove Kong specified `hosts` file as it conflicts
+# with the `hosts` modifications made by Docker (Compose)
 sed -i '/dns_hostsfile = spec\/fixtures\/hosts/d' /kong/spec/kong_tests.conf
 
-# run kong migrations
+# Run Kong migrations
+# As of 0.11.0, migrations are not executed automatically
+# on `kong start`
 kong migrations up
 
 exec "$@"

--- a/conf/kong-entrypoint.sh
+++ b/conf/kong-entrypoint.sh
@@ -11,4 +11,10 @@ else
     done
 fi
 
+# remove hosts configs for busted tests
+sed -i '/dns_hostsfile = spec\/fixtures\/hosts/d' /kong/spec/kong_tests.conf
+
+# run kong migrations
+kong migrations up
+
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   kong:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
   kong:
     build:


### PR DESCRIPTION
I have added KONG_VERSION variable to build kong from a given tag.
I did this to ensure that the docker image, will not break if Mashape adds breaking changes.
Kong 0.11.0 uses newer open resty, so I upped the version aswell.

I removed the dns settings because they conflicts with docker-compose.